### PR TITLE
don't steal focus from treeview when focusing item

### DIFF
--- a/lib/auto-reveal-in-sidebar.js
+++ b/lib/auto-reveal-in-sidebar.js
@@ -34,9 +34,6 @@ module.exports = {
                     // system panes have a uri
                     if (activePane.activeItem && !activePane.activeItem.uri) {
                         atom.commands.dispatch(workspaceView, 'tree-view:reveal-active-file');
-                        if (activePane) {
-                            activePane.activate();
-                        }
                     }
                 }
             });


### PR DESCRIPTION
there was an issue where clicking item on three view would focus the editor, which caused clicking treeview item and cmd+c or crl+c not to work since the item in tree view wasn't focused anymore.

this fixes that.
